### PR TITLE
test: migrate kspec/expekt to kotest 6.1.11

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,9 +29,8 @@ dependencies {
     implementation 'io.reactivex.rxjava2:rxkotlin:2.4.0'
     implementation 'org.jetbrains.kotlin:kotlin-reflect:2.3.20'
     implementation 'org.kodein.di:kodein-di:7.31.0'
-    testImplementation('com.github.raniejade.kspec:kspec-core:v0.4.0') { exclude group: 'org.jetbrains.kotlin' }
-    testImplementation('com.github.raniejade.kspec:kspec-junit-runner:v0.4.0') { exclude group: 'org.jetbrains.kotlin' }
-    testImplementation('com.winterbe:expekt:0.5.0') { exclude group: 'org.jetbrains.kotlin' }
+    testImplementation 'io.kotest:kotest-runner-junit5:6.1.11'
+    testImplementation 'io.kotest:kotest-assertions-core:6.1.11'
     testImplementation 'io.mockk:mockk:1.14.9'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.robolectric:robolectric:4.16.1'
@@ -114,6 +113,7 @@ android {
     testOptions {
         unitTests {
             all {
+                useJUnitPlatform()
                 jacoco {
                     includeNoLocationClasses = true
                 }

--- a/app/src/test/kotlin/com/unhappychoice/norimaki/extension/String+AnsiEscapeTest.kt
+++ b/app/src/test/kotlin/com/unhappychoice/norimaki/extension/String+AnsiEscapeTest.kt
@@ -1,55 +1,39 @@
 package com.unhappychoice.norimaki.extension
 
-import com.winterbe.expekt.expect
-import io.polymorphicpanda.kspec.KSpec
-import io.polymorphicpanda.kspec.describe
-import io.polymorphicpanda.kspec.it
-import io.polymorphicpanda.kspec.junit.JUnitKSpecRunner
-import org.junit.runner.RunWith
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
 
-@RunWith(JUnitKSpecRunner::class)
-class StringAnsiEscapeTest : KSpec() {
-    override fun spec() {
-        describe("String+AnsiEscape") {
-            it(".removeAnsiEscapeCode() should remove the code") {
-                expect("\u001b[3ASome string".removeAnsiEscapeCode()).to.equal("Some string")
-            }
-            it(".replaceAnsiColorCodeToHtml() should replace the code to html tag") {
-                val subject = "\u001b[30mSome string".replaceAnsiColorCodeToHtml()
-                expect(subject).to.equal("<font color=#111111>Some string</font>")
-            }
-            it(".replaceAnsiColorCodeToHtml() should replace the code to html tag") {
-                val subject = "\u001b[31mSome string".replaceAnsiColorCodeToHtml()
-                expect(subject).to.equal("<font color=#F00000>Some string</font>")
-            }
-            it(".replaceAnsiColorCodeToHtml() should replace the code to html tag") {
-                val subject = "\u001b[32mSome string".replaceAnsiColorCodeToHtml()
-                expect(subject).to.equal("<font color=#00F000>Some string</font>")
-            }
-            it(".replaceAnsiColorCodeToHtml() should replace the code to html tag") {
-                val subject = "\u001b[33mSome string".replaceAnsiColorCodeToHtml()
-                expect(subject).to.equal("<font color=#F0F000>Some string</font>")
-            }
-            it(".replaceAnsiColorCodeToHtml() should replace the code to html tag") {
-                val subject = "\u001b[34mSome string".replaceAnsiColorCodeToHtml()
-                expect(subject).to.equal("<font color=#0000F0>Some string</font>")
-            }
-            it(".replaceAnsiColorCodeToHtml() should replace the code to html tag") {
-                val subject = "\u001b[35mSome string".replaceAnsiColorCodeToHtml()
-                expect(subject).to.equal("<font color=#F000F0>Some string</font>")
-            }
-            it(".replaceAnsiColorCodeToHtml() should replace the code to html tag") {
-                val subject = "\u001b[36mSome string".replaceAnsiColorCodeToHtml()
-                expect(subject).to.equal("<font color=#00F0F0>Some string</font>")
-            }
-            it(".replaceAnsiColorCodeToHtml() should replace the code to html tag") {
-                val subject = "\u001b[37mSome string".replaceAnsiColorCodeToHtml()
-                expect(subject).to.equal("<font color=#F0F0F0>Some string</font>")
-            }
-            it(".replaceAnsiColorCodeToHtml() should replace the code to html tag") {
-                val subject = "\u001b[39mSome string".replaceAnsiColorCodeToHtml()
-                expect(subject).to.equal("<font color=#F0F0F0>Some string</font>")
-            }
+class StringAnsiEscapeTest : DescribeSpec({
+    describe("String+AnsiEscape") {
+        it(".removeAnsiEscapeCode() should remove the code") {
+            "[3ASome string".removeAnsiEscapeCode() shouldBe "Some string"
+        }
+        it(".replaceAnsiColorCodeToHtml() should replace 30 to #111111") {
+            "[30mSome string".replaceAnsiColorCodeToHtml() shouldBe "<font color=#111111>Some string</font>"
+        }
+        it(".replaceAnsiColorCodeToHtml() should replace 31 to #F00000") {
+            "[31mSome string".replaceAnsiColorCodeToHtml() shouldBe "<font color=#F00000>Some string</font>"
+        }
+        it(".replaceAnsiColorCodeToHtml() should replace 32 to #00F000") {
+            "[32mSome string".replaceAnsiColorCodeToHtml() shouldBe "<font color=#00F000>Some string</font>"
+        }
+        it(".replaceAnsiColorCodeToHtml() should replace 33 to #F0F000") {
+            "[33mSome string".replaceAnsiColorCodeToHtml() shouldBe "<font color=#F0F000>Some string</font>"
+        }
+        it(".replaceAnsiColorCodeToHtml() should replace 34 to #0000F0") {
+            "[34mSome string".replaceAnsiColorCodeToHtml() shouldBe "<font color=#0000F0>Some string</font>"
+        }
+        it(".replaceAnsiColorCodeToHtml() should replace 35 to #F000F0") {
+            "[35mSome string".replaceAnsiColorCodeToHtml() shouldBe "<font color=#F000F0>Some string</font>"
+        }
+        it(".replaceAnsiColorCodeToHtml() should replace 36 to #00F0F0") {
+            "[36mSome string".replaceAnsiColorCodeToHtml() shouldBe "<font color=#00F0F0>Some string</font>"
+        }
+        it(".replaceAnsiColorCodeToHtml() should replace 37 to #F0F0F0") {
+            "[37mSome string".replaceAnsiColorCodeToHtml() shouldBe "<font color=#F0F0F0>Some string</font>"
+        }
+        it(".replaceAnsiColorCodeToHtml() should replace 39 to #F0F0F0") {
+            "[39mSome string".replaceAnsiColorCodeToHtml() shouldBe "<font color=#F0F0F0>Some string</font>"
         }
     }
-}
+})

--- a/app/src/test/kotlin/com/unhappychoice/norimaki/presentation/screen/APITokenScreenTest.kt
+++ b/app/src/test/kotlin/com/unhappychoice/norimaki/presentation/screen/APITokenScreenTest.kt
@@ -1,33 +1,22 @@
 package com.unhappychoice.norimaki.presentation.screen
 
 import com.unhappychoice.norimaki.R
-import com.winterbe.expekt.expect
-import io.polymorphicpanda.kspec.KSpec
-import io.polymorphicpanda.kspec.describe
-import io.polymorphicpanda.kspec.it
-import io.polymorphicpanda.kspec.junit.JUnitKSpecRunner
-import org.junit.runner.RunWith
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
 
-@RunWith(JUnitKSpecRunner::class)
-class APITokenScreenTest : KSpec() {
-    lateinit var subject: APITokenScreen
+class APITokenScreenTest : DescribeSpec({
+    val subject = APITokenScreen()
 
-    override fun spec() {
-        beforeEach {
-            subject = APITokenScreen()
-        }
-
-        describe("APITokenScreen") {
-            describe(".getTitle()") {
-                it("should return title") {
-                    expect(subject.getTitle()).to.equal("Set api token")
-                }
+    describe("APITokenScreen") {
+        describe(".getTitle()") {
+            it("should return title") {
+                subject.getTitle() shouldBe "Set api token"
             }
-            describe(".getLayoutResource()") {
-                it("should return view resource") {
-                    expect(subject.getLayoutResource()).to.equal(R.layout.api_token_view)
-                }
+        }
+        describe(".getLayoutResource()") {
+            it("should return view resource") {
+                subject.getLayoutResource() shouldBe R.layout.api_token_view
             }
         }
     }
-}
+})

--- a/app/src/test/kotlin/com/unhappychoice/norimaki/presentation/screen/BuildListScreenTest.kt
+++ b/app/src/test/kotlin/com/unhappychoice/norimaki/presentation/screen/BuildListScreenTest.kt
@@ -1,38 +1,25 @@
 package com.unhappychoice.norimaki.presentation.screen
 
 import com.unhappychoice.norimaki.R
-import com.winterbe.expekt.expect
-import io.polymorphicpanda.kspec.KSpec
-import io.polymorphicpanda.kspec.describe
-import io.polymorphicpanda.kspec.it
-import io.polymorphicpanda.kspec.junit.JUnitKSpecRunner
-import org.junit.runner.RunWith
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
 
-@RunWith(JUnitKSpecRunner::class)
-class BuildListScreenTest : KSpec() {
-    lateinit var subject: BuildListScreen
+class BuildListScreenTest : DescribeSpec({
+    val subject = BuildListScreen("")
 
-    override fun spec() {
-        beforeEach {
-            subject = BuildListScreen("")
-        }
-
-        describe("BuildListScreen") {
-            describe(".getTitle()") {
-                it("should return title") {
-                    expect(BuildListScreen("").getTitle()).to.equal("Recent Builds")
-                }
-                it("should return title") {
-                    expect(BuildListScreen("unhappychoice/Norimaki").getTitle()).to.equal("unhappychoice/Norimaki")
-                }
+    describe("BuildListScreen") {
+        describe(".getTitle()") {
+            it("should return 'Recent Builds' for empty path") {
+                BuildListScreen("").getTitle() shouldBe "Recent Builds"
             }
-            describe(".getLayoutResource()") {
-                it("should return view resource") {
-                    expect(subject.getLayoutResource()).to.equal(R.layout.build_list_view)
-                }
+            it("should return the path itself when set") {
+                BuildListScreen("unhappychoice/Norimaki").getTitle() shouldBe "unhappychoice/Norimaki"
+            }
+        }
+        describe(".getLayoutResource()") {
+            it("should return view resource") {
+                subject.getLayoutResource() shouldBe R.layout.build_list_view
             }
         }
     }
-}
-
-
+})

--- a/app/src/test/kotlin/com/unhappychoice/norimaki/presentation/screen/BuildScreenTest.kt
+++ b/app/src/test/kotlin/com/unhappychoice/norimaki/presentation/screen/BuildScreenTest.kt
@@ -1,43 +1,36 @@
 package com.unhappychoice.norimaki.presentation.screen
 
 import com.github.unhappychoice.circleci.v1.response.Build
-import io.mockk.every
-import io.mockk.mockk
 import com.unhappychoice.norimaki.R
 import com.unhappychoice.norimaki.domain.model.revisionString
-import com.winterbe.expekt.expect
-import io.polymorphicpanda.kspec.KSpec
-import io.polymorphicpanda.kspec.describe
-import io.polymorphicpanda.kspec.it
-import io.polymorphicpanda.kspec.junit.JUnitKSpecRunner
-import org.junit.runner.RunWith
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
 
-@RunWith(JUnitKSpecRunner::class)
-class BuildScreenTest : KSpec() {
+class BuildScreenTest : DescribeSpec({
     lateinit var subject: BuildScreen
     lateinit var build: Build
 
-    override fun spec() {
-        beforeEach {
-            build = mockk {
-                every { branch } returns "main"
-                every { buildNum } returns 123
-                every { vcsRevision } returns "abc123def"
-            }
-            subject = BuildScreen(build)
+    beforeEach {
+        build = mockk {
+            every { branch } returns "main"
+            every { buildNum } returns 123
+            every { vcsRevision } returns "abc123def"
         }
+        subject = BuildScreen(build)
+    }
 
-        describe("BuildScreen") {
-            describe(".getTitle()") {
-                it("should return title") {
-                    expect(subject.getTitle()).to.equal(build.revisionString())
-                }
+    describe("BuildScreen") {
+        describe(".getTitle()") {
+            it("should return title") {
+                subject.getTitle() shouldBe build.revisionString()
             }
-            describe(".getLayoutResource()") {
-                it("should return view resource") {
-                    expect(subject.getLayoutResource()).to.equal(R.layout.build_view)
-                }
+        }
+        describe(".getLayoutResource()") {
+            it("should return view resource") {
+                subject.getLayoutResource() shouldBe R.layout.build_view
             }
         }
     }
-}
+})

--- a/app/src/test/kotlin/com/unhappychoice/norimaki/presentation/screen/BuildStepScreenTest.kt
+++ b/app/src/test/kotlin/com/unhappychoice/norimaki/presentation/screen/BuildStepScreenTest.kt
@@ -2,41 +2,33 @@ package com.unhappychoice.norimaki.presentation.screen
 
 import com.github.unhappychoice.circleci.v1.response.Build
 import com.github.unhappychoice.circleci.v1.response.BuildStep
+import com.unhappychoice.norimaki.R
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
-import com.unhappychoice.norimaki.R
-import com.winterbe.expekt.expect
-import io.polymorphicpanda.kspec.KSpec
-import io.polymorphicpanda.kspec.describe
-import io.polymorphicpanda.kspec.it
-import io.polymorphicpanda.kspec.junit.JUnitKSpecRunner
-import org.junit.runner.RunWith
 
-@RunWith(JUnitKSpecRunner::class)
-class BuildStepScreenTest : KSpec() {
+class BuildStepScreenTest : DescribeSpec({
     lateinit var subject: BuildStepScreen
     lateinit var build: Build
     lateinit var buildStep: BuildStep
-    val stepIndex = 0
 
-    override fun spec() {
-        beforeEach {
-            build = mockk(relaxed = true)
-            buildStep = mockk { every { name } returns "build name" }
-            subject = BuildStepScreen(build, buildStep)
-        }
+    beforeEach {
+        build = mockk(relaxed = true)
+        buildStep = mockk { every { name } returns "build name" }
+        subject = BuildStepScreen(build, buildStep)
+    }
 
-        describe("BuildStepScreen") {
-            describe(".getTitle()") {
-                it("should return title") {
-                    expect(subject.getTitle()).to.equal(buildStep.name)
-                }
+    describe("BuildStepScreen") {
+        describe(".getTitle()") {
+            it("should return title") {
+                subject.getTitle() shouldBe buildStep.name
             }
-            describe(".getLayoutResource()") {
-                it("should return view resource") {
-                    expect(subject.getLayoutResource()).to.equal(R.layout.build_step_view)
-                }
+        }
+        describe(".getLayoutResource()") {
+            it("should return view resource") {
+                subject.getLayoutResource() shouldBe R.layout.build_step_view
             }
         }
     }
-}
+})


### PR DESCRIPTION
## Summary
- Replace \`com.github.raniejade.kspec:kspec-core\`, \`kspec-junit-runner\`, and \`com.winterbe:expekt\` with \`io.kotest:kotest-runner-junit5:6.1.11\` + \`kotest-assertions-core:6.1.11\`.
- Enable \`useJUnitPlatform()\` for unit tests so kotest 6.x runs on JUnit 5.
- Rewrite all 5 specs (19 tests total) from \`KSpec\`'s \`describe { it { } }\` + \`expect(x).to.equal(y)\` to \`DescribeSpec\` + \`x shouldBe y\`.

## Why
\`raniejade/kspec\` is dead — the v0.4.0 build is **permanently errored on JitPack**, so \`testImplementation com.github.raniejade.kspec:*:v0.4.0\` cannot be resolved on a clean checkout. CI was failing with:

\`\`\`
> Could not find com.github.raniejade.kspec:kspec-junit-runner:v0.4.0.
\`\`\`

The same author (raniejade) went on to write [\`kotest\`](https://github.com/kotest/kotest), which is the de-facto kspec successor and supports the same \`describe / it\` BDD style via \`DescribeSpec\`.

## Test plan
- [x] \`./gradlew testDebugUnitTest\` passes locally on JDK 21
- [x] All 19 tests across the 5 spec files run and pass (verified via \`build/test-results/testDebugUnitTest/TEST-*.xml\`)
- [ ] CircleCI \`build\` and \`test\` jobs go green

Closes unhappychoice/oss-issue-opener#120

🤖 Generated with [Claude Code](https://claude.com/claude-code)