### PR TITLE
fix(build): bump minSdk to 23 and ignore JitPack-hosted dep in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
       time: "12:00"
       timezone: Asia/Tokyo
     open-pull-requests-limit: 20
+    ignore:
+      # JitPack does not expose maven-metadata.xml for GitHub-built
+      # artifacts, so Dependabot's version lookup fails with HTTP 401.
+      - dependency-name: "com.github.unhappychoice:circleci"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,7 +79,7 @@ android {
     }
     defaultConfig {
         applicationId "com.unhappychoice.norimaki"
-        minSdk 21
+        minSdk 23
         targetSdk 35
         versionCode System.getenv("CIRCLE_BUILD_NUM") as Integer ?: 1
         versionName "1.1.2"


### PR DESCRIPTION
## Summary

Two CI failures observed on default branch (#181 in oss-issue-opener tracker):

### CircleCI build
The manifest merger rejected the configuration after Dependabot merged `material 1.13.0 → 1.14.0`:

```
uses-sdk:minSdkVersion 21 cannot be smaller than version 23 declared in
library [com.google.android.material:material:1.14.0]
```

`com.google.android.material:material:1.14.0` requires `minSdkVersion >= 23`. Bump `minSdk` from 21 to 23 (Android 6.0) to match the library requirement.

### Dependabot
Dependabot was reporting `private_source_authentication_failure` on `https://jitpack.io` for `com.github.unhappychoice:circleci`. JitPack does not serve `maven-metadata.xml` for GitHub-built artifacts (the request returns HTTP 401), so Dependabot cannot enumerate versions. The build itself still resolves the pinned version (`2.1.0`) because the actual artifact is fetched, just not the metadata directory.

Add an `ignore` entry in `.github/dependabot.yml` so the version check is skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)