### PR TITLE
fix(build): apply kotlin-android plugin 2.4.0 explicitly

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
     id 'com.github.triplet.play' version '4.0.0'
     id 'jacoco'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'com.android.application'
-    id 'org.jetbrains.kotlin.android'
     id 'com.github.triplet.play' version '4.0.0'
     id 'jacoco'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-plugins {
-    id 'com.android.application' version '9.2.1' apply false
-}
-
 buildscript {
     dependencies {
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.4.0'
     }
+}
+
+plugins {
+    id 'com.android.application' version '9.2.1' apply false
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,12 @@
 
 plugins {
     id 'com.android.application' version '9.2.1' apply false
-    id 'org.jetbrains.kotlin.android' version '2.4.0' apply false
+}
+
+buildscript {
+    dependencies {
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.4.0'
+    }
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@
 
 plugins {
     id 'com.android.application' version '9.2.1' apply false
+    id 'org.jetbrains.kotlin.android' version '2.4.0' apply false
 }
 
 


### PR DESCRIPTION
## Summary
- AGP 9.2.1 bundles the Kotlin compiler at 2.2.0 (`compiler version 2.2.0 can read versions up to 2.3.0`)
- After Dependabot bumped `kotlin-reflect` / `kotlin-stdlib` to 2.4.0, every file fails to compile with `Class 'kotlin.Unit' was compiled with an incompatible version of Kotlin. The actual metadata version is 2.4.0`
- Apply the Kotlin Android plugin explicitly at 2.4.0 to align the compiler with the runtime artifacts

Closes unhappychoice/oss-issue-opener#224

## Test plan
- [ ] CircleCI `build` job passes