### PR TITLE
fix(ci): raise Gradle daemon heap to fix D8 OOM on deploy

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
## Summary
The CircleCI `deploy` job (build [#1854](https://circleci.com/gh/circleci-tools/Norimaki/1854)) was dying with `java.lang.OutOfMemoryError: Java heap space` during D8 dexing. The Gradle daemon was running with the default ~512 MiB — the launcher-level `JVM_OPTS=-Xmx3200m` in `.circleci/config.yml` only affects the launcher, not the daemon that runs the tasks.

Enable `org.gradle.jvmargs` in `gradle.properties`:

- `-Xmx2048m` — comfortable heap for D8 with the current dependency graph (Material 1.14.0, ConstraintLayout 2.2.1, OkHttp 5.4.0, Kodein, RxJava, …).
- `-XX:MaxMetaspaceSize=1024m` — replaces the removed `MaxPermSize` (Java 8+).
- Keep `-XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8`.

## Test plan
- [ ] CircleCI `deploy` job passes on this PR (previous OOM at D8 stage should be gone).

Closes unhappychoice/oss-issue-opener#293.