### PR TITLE
ci: run deploy on a large resource class to stop the daemon being OOM-killed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,8 +54,10 @@ jobs:
     working_directory: ~/norimaki
     docker:
       - image: cimg/android:2026.02.1
+    resource_class: large
     environment:
-      JVM_OPTS: -Xmx3200m
+      JVM_OPTS: -Xmx6g
+      GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2
     steps:
       - checkout
       - *restore_cache


### PR DESCRIPTION
## Why

The `deploy` job on `master` is still red ([build #1881](https://circleci.com/gh/circleci-tools/Norimaki/1881)), but the failure mode changed after #451:

```
The message received from the daemon indicates that the daemon has disappeared.
...
* What went wrong:
Gradle build daemon disappeared unexpectedly (it may have been killed or may have crashed)
```

That is the kernel OOM-killer, not a Java heap OOM. The docker `medium` container has 4 GiB and hosts both the Gradle daemon (2 GiB heap + 1 GiB metaspace) and a separate Kotlin compile daemon; the daemon dies right after `compileReleaseKotlin`, while `processReleaseResources` and dexing still need heap.

DroidFlyer hit this exact failure and fixed it in bitflyer-tools/DroidFlyer@27459f0. This applies the same recipe.

## What

Deploy job only (build/test stay on `medium`):

- `resource_class: large` — 8 GiB instead of 4 GiB
- `JVM_OPTS: -Xmx6g`
- `GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2` — CI is one-shot, so no long-running daemon, and workers are capped so the Kotlin daemon does not fan out

## Verification

`deploy` only runs on `master`, so this PR's CI exercises `build` and `test`; the OOM path is confirmed on merge.

Refs unhappychoice/oss-issue-opener#298

🤖 Generated with [Claude Code](https://claude.com/claude-code)